### PR TITLE
RFC: add String function to Request

### DIFF
--- a/request.go
+++ b/request.go
@@ -2,7 +2,9 @@ package gentleman
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
@@ -310,6 +312,21 @@ func (r *Request) Clone() *Request {
 	req.Context = r.Context.Clone()
 	req.Middleware = r.Middleware.Clone()
 	return req
+}
+
+// String returns a string representation of a HTTP request body
+func (r *Request) String() string {
+	tmp := r.Clone()
+	tmp.dispatched = true
+	ctx := NewDispatcher(tmp).BuildFinalRequest()
+
+	s, err := ioutil.ReadAll(ctx.Request.Body)
+	if err != nil {
+		return err.Error()
+	}
+	defer ctx.Request.Body.Close()
+
+	return fmt.Sprintf("%s", s)
 }
 
 // NewDefaultTransport returns a new http.Transport with default values

--- a/request_test.go
+++ b/request_test.go
@@ -70,6 +70,37 @@ func TestRequestAlreadyDispatched(t *testing.T) {
 	st.Reject(t, err, nil)
 }
 
+func TestRequestString(t *testing.T) {
+	body := `{"foo": "bar", "id": 123}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := ioutil.ReadAll(r.Body)
+		st.Expect(t, err, nil)
+		st.Expect(t, fmt.Sprintf("%s", b), body)
+
+		fmt.Fprintln(w, "Hello, world")
+	}))
+	defer ts.Close()
+
+	{
+		req := NewRequest().URL(ts.URL).JSON(body)
+		st.Expect(t, req.String(), body)
+		_, err := req.Send()
+		st.Expect(t, err, nil)
+	}
+	{
+		req := NewRequest().URL(ts.URL).BodyString(body).Type("json")
+		st.Expect(t, req.String(), body)
+		_, err := req.Send()
+		st.Expect(t, err, nil)
+	}
+	{
+		req := NewRequest().URL(ts.URL).Body(strings.NewReader(body)).Type("json")
+		st.Expect(t, req.String(), body)
+		_, err := req.Send()
+		st.Expect(t, err, nil)
+	}
+}
+
 func TestMiddlewareErrorInjectionAndInterception(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello, world")


### PR DESCRIPTION
I imagined that cloning a request and running its request phase would be enough to have a representation of its body. However this solution doesn't work when the request is generated using an `io.Reader`

If you run the tests i added the last assert fails.