### PR TITLE
fix(#55): allow trusted hosts on redirect

### DIFF
--- a/plugins/redirect/redirect.go
+++ b/plugins/redirect/redirect.go
@@ -38,6 +38,16 @@ type Options struct {
 	// `SensitiveHeaders` will be removed from the request
 	Trusted bool
 
+	// TrustedHostSuffixes is a list of host suffixes that will be forwarded all
+	// headers. Hosts not in the list will have the headers specified in
+	// `SensitiveHeaders` removed. If `Trusted` is set, this value is ignored.
+	//
+	// Using suffixes can create some unexpected collisions. For instance, a
+	// suffix of `trusted.com` will match a URL with `untrusted.com`. Consider
+	// always including a leading `.` to only match your true trusted hosts if
+	// practical, e.g. `.trusted.com`.
+	TrustedHostSuffixes []string
+
 	// SensitiveHeaders is a map of sensitive HTTP headers that a user
 	// doesn't want passed on a redirect
 	SensitiveHeaders []string
@@ -85,7 +95,8 @@ func redirectPolicy(opts Options, req *http.Request, pool []*http.Request) error
 }
 
 func copyHeaders(k string, vv []string, opts Options, req *http.Request) {
-	if !opts.Trusted {
+	trustedHost := isTrustedHost(opts, req)
+	if !opts.Trusted && !trustedHost {
 		for _, v := range opts.SensitiveHeaders {
 			if strings.ToLower(k) == strings.ToLower(v) {
 				return
@@ -94,4 +105,13 @@ func copyHeaders(k string, vv []string, opts Options, req *http.Request) {
 	}
 
 	req.Header[k] = vv
+}
+
+func isTrustedHost(opts Options, req *http.Request) bool {
+	for _, v := range opts.TrustedHostSuffixes {
+		if strings.HasSuffix(req.Host, v) {
+			return true
+		}
+	}
+	return false
 }

--- a/plugins/redirect/redirect_test.go
+++ b/plugins/redirect/redirect_test.go
@@ -1,10 +1,11 @@
 package redirect
 
 import (
-	"github.com/nbio/st"
-	"gopkg.in/h2non/gentleman.v2/context"
 	"net/http"
 	"testing"
+
+	"github.com/nbio/st"
+	"gopkg.in/h2non/gentleman.v2/context"
 )
 
 func TestRedirectPolicy(t *testing.T) {
@@ -19,6 +20,54 @@ func TestRedirectPolicy(t *testing.T) {
 	err := redirectPolicy(opts, req, pool)
 	st.Expect(t, err, nil)
 	st.Expect(t, req.Header.Get("foo"), "bar")
+}
+
+func TestRedirectPolicyAllowsSensitiveHeadersWhenTrusted(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("foo", "bar")
+	headers.Set("Authorization", "bar")
+
+	req := &http.Request{Header: make(http.Header)}
+	prevReq := &http.Request{Header: headers}
+	pool := []*http.Request{prevReq}
+	opts := Options{SensitiveHeaders: []string{"Authorization"}, Trusted: true}
+
+	err := redirectPolicy(opts, req, pool)
+	st.Expect(t, err, nil)
+	st.Expect(t, req.Header.Get("foo"), "bar")
+	st.Expect(t, req.Header.Get("Authorization"), "bar")
+}
+
+func TestRedirectPolicyAllowsSensitiveHeadersForTrustedHosts(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("foo", "bar")
+	headers.Set("Authorization", "bar")
+
+	req := &http.Request{Host: "www.trusted.com", Header: make(http.Header)}
+	prevReq := &http.Request{Header: headers}
+	pool := []*http.Request{prevReq}
+	opts := Options{SensitiveHeaders: []string{"Authorization"}, TrustedHostSuffixes: []string{".trusted.com"}}
+
+	err := redirectPolicy(opts, req, pool)
+	st.Expect(t, err, nil)
+	st.Expect(t, req.Header.Get("foo"), "bar")
+	st.Expect(t, req.Header.Get("Authorization"), "bar")
+}
+
+func TestRedirectPolicyRemovesSensitiveHeadersForNonTrustedHosts(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("foo", "bar")
+	headers.Set("Authorization", "bar")
+
+	req := &http.Request{Host: "untrusted.com", Header: make(http.Header)}
+	prevReq := &http.Request{Header: headers}
+	pool := []*http.Request{prevReq}
+	opts := Options{SensitiveHeaders: []string{"Authorization"}, TrustedHostSuffixes: []string{".trusted.com"}}
+
+	err := redirectPolicy(opts, req, pool)
+	st.Expect(t, err, nil)
+	st.Expect(t, req.Header.Get("foo"), "bar")
+	st.Expect(t, req.Header.Get("Authorization"), "")
 }
 
 func TestRedirectPolicyRemoveSensitiveHeaders(t *testing.T) {


### PR DESCRIPTION
In order to avoid leaking sensitive information, the redirect plugin
does not forward sensitive headers unless the opts.Trusted field is
true. This commit adds an additional capability to also provide a list
of trusted host suffixes.

The opts.Trusted value will override any suffix list. Suffixes are not
perfect and care should be given to choose a value appropriate for the
given environment. For example, a 'trusted.com' suffix will match a host
that was 'untrusted.com.' A leading '.' can be used to avoid this, e.g.
'.trusted.com.'